### PR TITLE
chore(dca-backend): LIT-4363 - Modify cache time for top tokens & eth price

### DIFF
--- a/packages/dca-backend/src/lib/agenda/jobs/executeDCASwap/baseMemeCoinLoader.ts
+++ b/packages/dca-backend/src/lib/agenda/jobs/executeDCASwap/baseMemeCoinLoader.ts
@@ -5,7 +5,7 @@ import Cache from 'node-cache';
 import { wrapNodeCacheForDataloader } from './dataLoaderCache';
 import { env } from '../../../env';
 
-const cache = new Cache({ checkperiod: 0, stdTTL: 5, useClones: false });
+const cache = new Cache({ checkperiod: 0, stdTTL: 60 * 10, useClones: false }); // 10 minute cache
 
 const { COINRANKING_API_KEY } = env;
 

--- a/packages/dca-backend/src/lib/agenda/jobs/executeDCASwap/ethPriceLoader.ts
+++ b/packages/dca-backend/src/lib/agenda/jobs/executeDCASwap/ethPriceLoader.ts
@@ -3,7 +3,7 @@ import Cache from 'node-cache';
 
 import { wrapNodeCacheForDataloader } from './dataLoaderCache';
 
-const cache = new Cache({ checkperiod: 0, stdTTL: 5, useClones: false });
+const cache = new Cache({ checkperiod: 0, stdTTL: 60, useClones: false });
 
 export function assertEthereumPriceData(
   data: unknown

--- a/packages/dca-backend/src/lib/agenda/jobs/executeDCASwap/executeDCASwap.ts
+++ b/packages/dca-backend/src/lib/agenda/jobs/executeDCASwap/executeDCASwap.ts
@@ -183,6 +183,12 @@ export async function executeDCASwap(job: JobType): Promise<void> {
       data: { purchaseAmount, walletAddress },
     } = job.attrs;
 
+    consola.log('Starting DCA swap job...', {
+      _id,
+      purchaseAmount,
+      walletAddress,
+    });
+
     // Fetch top coin first to get the target token
     consola.debug('Fetching top coin...');
     const topCoin = await getTopBaseMemeCoin();


### PR DESCRIPTION
Increased cache windows for eth pricing and top token lookups
- Improves job processing time, and makes job processing less brittle if downstreams services are unavailable temporarily.
- Added a log for each time we start processing a job.
