### PR TITLE
feat(dca-backend): LIT-4364 - Disable jobs failing for known-fatal reasons (user can re-enable them)

### DIFF
--- a/packages/dca-backend/src/lib/jobWorker.ts
+++ b/packages/dca-backend/src/lib/jobWorker.ts
@@ -1,4 +1,4 @@
-import { Job } from '@whisthub/agenda';
+import consola from 'consola';
 
 import { createAgenda, getAgenda } from './agenda/agendaClient';
 import { executeDCASwapJobDef } from './agenda/jobs';
@@ -9,10 +9,29 @@ export async function startWorker() {
 
   const agenda = getAgenda();
 
-  agenda.define(executeDCASwapJobDef.jobName, async (job: Job<executeDCASwapJobDef.JobType>) => {
+  agenda.define(executeDCASwapJobDef.jobName, async (job: executeDCASwapJobDef.JobType) => {
     // TODO: add job-aware logic such as cool-downs in case of repeated failures here
 
-    await executeDCASwapJobDef.processJob(job);
+    try {
+      await executeDCASwapJobDef.processJob(job);
+    } catch (err) {
+      const error = err as Error;
+      // If we get an error we know is non-transient (the user must fix the state), disable the job
+      // The user can re-enable it after resolving the fatal error.
+      if (
+        error?.message?.includes('No native eth balance on account') ||
+        error?.message?.includes('Not enough ETH to pay for gas for token approval') ||
+        error?.message?.includes('Not enough WETH to swap') ||
+        error?.message?.includes('No wEth balance for account')
+      ) {
+        consola.log(`Disabling job due to fatal error: ${error.message}`);
+        job.disable();
+        await job.save();
+        throw new Error(`DCA schedule disabled due to fatal error: ${error.message}`);
+      }
+      // Other errors just bubble up to the job doc
+      throw err;
+    }
   });
 
   return agenda;


### PR DESCRIPTION
Adds logic that will disable a job if it fails for 4 known-fatal-until-user-intervenes cases:
- No native ETH balance is on the PKP account on Base
- Not enough ETH balance exists on the PKP account on Base to pay for gas fees ('dust' levels)
- No WETH balance exists on the PKP account on Base with which to make the swaps
- Not enough WETH balance exists on the PKP account on Base with which to make the swaps

The job error message shown in the DCA frontend tells the user that the job was disabled because of this type of error if it happens, and the user can click 'resume' on the schedule once they've (re)funded the account.